### PR TITLE
Add timeout to curl request

### DIFF
--- a/auto-reroute.sh
+++ b/auto-reroute.sh
@@ -125,7 +125,7 @@ fi
 		((count++))
 		echo "Testing single segment download speed from ${route_names[$count]}..."
 		##need sed now because some european versions of curl insert a , in the speed results
-		messyspeed=$(echo -n "scale=2; " && curl -4 -s -L ${test_files[$count]} -w "%{speed_download}" -o /dev/null | sed "s/\,/\./g")
+		messyspeed=$(echo -n "scale=2; " && curl -m 30 -4 -s -L ${test_files[$count]} -w "%{speed_download}" -o /dev/null | sed "s/\,/\./g")
 		if [ -z "$(echo $messyspeed | awk -F\; '{print $2}'| sed 's/ //g')" ]; then
 			echo "There was an issue downloading ${test_files[$count]}"
 			speed="0"


### PR DESCRIPTION
Added timeout to curl download of test files. No point wasting time on slower networks downloading the whole file. Thirty seconds (or less) should give you a pretty good idea.